### PR TITLE
Block committing or pushing directly to the main branch

### DIFF
--- a/.github/branch-protection.yml
+++ b/.github/branch-protection.yml
@@ -1,0 +1,42 @@
+name: Branch Protection Settings
+
+# This file documents the branch protection settings that should be applied
+# on GitHub. These settings need to be manually configured in the GitHub repository settings.
+
+# Branch Protection for 'main' branch
+main:
+  # Require pull request reviews before merging
+  required_pull_request_reviews:
+    required_approving_review_count: 1
+    dismiss_stale_reviews: true
+    require_code_owner_reviews: false
+  
+  # Require status checks to pass before merging
+  required_status_checks:
+    strict: true
+    contexts:
+      - test-and-lint
+  
+  # Restrict who can push to the branch
+  restrictions:
+    users: []
+    teams: []
+    apps: []
+  
+  # Do not allow bypassing the above settings
+  enforce_admins: true
+  
+  # Do not allow deletion of the branch
+  allow_deletions: false
+  
+  # Do not allow force pushes to the branch
+  allow_force_pushes: false
+
+# How to apply these settings:
+# 1. Go to your GitHub repository
+# 2. Click on "Settings"
+# 3. Click on "Branches" in the left sidebar
+# 4. Under "Branch protection rules", click "Add rule"
+# 5. Enter "main" as the branch name pattern
+# 6. Configure the settings as described above
+# 7. Click "Create" or "Save changes" 

--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -1,0 +1,22 @@
+name: Branch Protection
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  check-direct-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if push is from PR
+        run: |
+          # If the push is from a PR merge, the GitHub event will have a pull_request object
+          if [ "${{ github.event_name }}" == "push" ] && [ -z "${{ github.event.pull_request }}" ]; then
+            # Check if the actor is a GitHub Action (for automated workflows)
+            if [[ "${{ github.actor }}" != "github-actions[bot]" && "${{ github.actor }}" != "dependabot[bot]" ]]; then
+              echo "ERROR: Direct pushes to the main branch are not allowed."
+              echo "Please create a feature branch and submit a pull request instead."
+              exit 1
+            fi
+          fi 

--- a/README.md
+++ b/README.md
@@ -76,3 +76,32 @@ npm test
 ## License
 
 This project is licensed under the MIT License - see the LICENSE file for details. 
+
+## Contributing
+
+### Branch Protection
+
+This project has branch protection rules to maintain code quality:
+
+1. Direct commits and pushes to the `main` branch are not allowed
+2. All changes must be made through pull requests
+3. Pull requests require at least one review before merging
+4. All status checks must pass before merging
+
+### Setting Up Git Hooks
+
+To prevent accidental commits/pushes to protected branches, run:
+
+```bash
+./scripts/setup-git-hooks.sh
+```
+
+This will install pre-commit and pre-push hooks that block direct commits to the main branch.
+
+### Contribution Workflow
+
+1. Create a feature branch from `main`
+2. Make your changes
+3. Submit a pull request to `main`
+4. Address any review comments
+5. Once approved and all checks pass, your PR can be merged 

--- a/docs/BRANCH_PROTECTION.md
+++ b/docs/BRANCH_PROTECTION.md
@@ -1,0 +1,75 @@
+# Branch Protection Setup
+
+This document explains how to set up branch protection for the `main` branch to prevent direct commits and pushes.
+
+## GitHub Branch Protection Rules
+
+To set up branch protection on GitHub:
+
+1. Go to the repository on GitHub
+2. Click on "Settings"
+3. In the left sidebar, click on "Branches"
+4. Under "Branch protection rules", click "Add rule"
+5. In the "Branch name pattern" field, enter `main`
+6. Configure the following settings:
+
+### Required Settings
+
+- ✅ "Require a pull request before merging"
+  - ✅ "Require approvals" (set to at least 1)
+  - ✅ "Dismiss stale pull request approvals when new commits are pushed"
+
+- ✅ "Require status checks to pass before merging"
+  - ✅ "Require branches to be up to date before merging"
+  - Add the following status checks:
+    - `test-and-lint` (from the main.yml workflow)
+    - `check-direct-push` (from the branch-protection.yml workflow)
+
+- ✅ "Do not allow bypassing the above settings"
+
+- ❌ "Allow force pushes"
+- ❌ "Allow deletions"
+
+7. Click "Create" or "Save changes"
+
+## Local Git Hooks
+
+To prevent accidental commits or pushes to the `main` branch from your local machine, you can set up Git hooks:
+
+```bash
+# Option 1: Run the setup script directly
+./scripts/setup-git-hooks.sh
+
+# Option 2: Use the npm script
+npm run setup:hooks
+```
+
+This will install pre-commit and pre-push hooks that block direct commits and pushes to the `main` branch.
+
+## How It Works
+
+The protection works at two levels:
+
+1. **Local protection**: Git hooks prevent developers from accidentally committing or pushing directly to `main`
+2. **Server protection**: GitHub branch protection rules enforce that all changes to `main` must come through pull requests
+
+## Troubleshooting
+
+### Bypassing Hooks (Emergency Only)
+
+In case you need to bypass the hooks for a legitimate reason (which should be rare), you can use:
+
+```bash
+git commit --no-verify
+git push --no-verify
+```
+
+**Note**: This will bypass the local hooks, but GitHub's branch protection will still block direct pushes to `main`.
+
+### Hook Not Working
+
+If the hooks aren't working:
+
+1. Check if they're executable: `ls -la .git/hooks/`
+2. Make them executable if needed: `chmod +x .git/hooks/pre-commit .git/hooks/pre-push`
+3. Run the setup script again: `npm run setup:hooks` 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test:coverage": "jest --coverage --config jest.config.cjs",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx --config eslint.config.cjs",
     "lint:fix": "eslint . --ext .js,.jsx,.ts,.tsx --fix --config eslint.config.cjs",
-    "analyze:bundle": "vite build"
+    "analyze:bundle": "vite build",
+    "setup:hooks": "chmod +x ./scripts/setup-git-hooks.sh && ./scripts/setup-git-hooks.sh"
   },
   "keywords": [],
   "author": "",

--- a/scripts/setup-git-hooks.sh
+++ b/scripts/setup-git-hooks.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Create scripts directory if it doesn't exist
+mkdir -p "$(dirname "$0")"
+
+# Create hooks directory if it doesn't exist
+HOOKS_DIR=".git/hooks"
+mkdir -p "$HOOKS_DIR"
+
+# Create pre-commit hook
+cat > "$HOOKS_DIR/pre-commit" << 'EOF'
+#!/bin/bash
+
+# Get current branch
+BRANCH=$(git symbolic-ref --short HEAD)
+
+# Block commits directly to main branch
+if [ "$BRANCH" = "main" ]; then
+  echo "ERROR: Direct commits to the main branch are not allowed."
+  echo "Please create a feature branch and submit a pull request instead."
+  exit 1
+fi
+
+exit 0
+EOF
+
+# Create pre-push hook
+cat > "$HOOKS_DIR/pre-push" << 'EOF'
+#!/bin/bash
+
+# This hook prevents pushing directly to the main branch
+
+# Parse the arguments passed to the pre-push hook
+# The pre-push hook receives the following arguments:
+# $1 - Name of the remote to which the push is being done
+# $2 - URL to which the push is being done
+
+remote="$1"
+url="$2"
+
+# Get the current branch name
+BRANCH=$(git symbolic-ref --short HEAD)
+
+# Block pushes directly to main branch
+if [ "$BRANCH" = "main" ]; then
+  echo "ERROR: Direct pushes to the main branch are not allowed."
+  echo "Please create a feature branch and submit a pull request instead."
+  exit 1
+fi
+
+# If pushing to a different branch, allow the push
+exit 0
+EOF
+
+# Make the hooks executable
+chmod +x "$HOOKS_DIR/pre-commit"
+chmod +x "$HOOKS_DIR/pre-push"
+
+echo "Git hooks installed successfully!"
+echo "Direct commits and pushes to the main branch are now blocked."
+echo "Use feature branches and pull requests instead." 


### PR DESCRIPTION
Run `npm run setup:hooks` locally to avoid direct commits and pushes to the main branch from local